### PR TITLE
Update interpolate.md

### DIFF
--- a/components/interpolate.md
+++ b/components/interpolate.md
@@ -90,7 +90,7 @@ function TranslatableView(props) {
 a) Use standard interpolation of i18next and dangerously insert that:
 
 ```js
-<div dangerouslySetInnerHTML={t('my-label', { link: yourURL }} />
+<div dangerouslySetInnerHTML={{ __html: t('my-label', { link: yourURL }) }} />
 ```
 
 b) use markdown, eg. [react-remarkable](https://github.com/acdlite/react-remarkable) and pass markdown formatted content from translations to the markdown component.


### PR DESCRIPTION
Alternatives option A:
The current example not working, Its missing ending parentheses.
After I added the parentheses got an error: Uncaught Error: `props.dangerouslySetInnerHTML` must be in the form `{__html: ...}`. Please visit https://fb.me/react-invariant-dangerously-set-inner-html for more information.