### PR TITLE
Fix the I18n (render prop) example

### DIFF
--- a/components/i18n-render-prop.md
+++ b/components/i18n-render-prop.md
@@ -17,7 +17,7 @@ To learn more about using the `t` function have a look at i18next documentation:
 import React from 'react';
 import { I18n } from 'react-i18next';
 
-function TranslatableView() {
+function TranslatableView(props) {
   const { t } = props;
 
   return (


### PR DESCRIPTION
The example function `TranslatableView` uses `props` which is undefined, because it hasn't been passed via the function's parameters.