### PR TITLE
Providing resources to use i18n.language feature

### DIFF
--- a/misc/testing.md
+++ b/misc/testing.md
@@ -101,3 +101,17 @@ it('dispatches SORT_TABLE', () => {
 });
 ```
 
+As translations aren't provided, `this.props.i18n.language` will be `undefined`. In case your application relies on that value you can mock resources by adding these lines to the object passed to init:
+
+```
+i18n
+  .init({
+    ...
+    fallbackLng: 'en',
+    resources: {
+      en: {},
+      de: {}
+})
+```
+
+Now in your component `this.props.i18n.language` will return `en`.


### PR DESCRIPTION
In my components I often do:

```
this.language = this.props.i18n.language.split("-")[0];
``` 

If resources aren't defined the test throws the following error:

```
TypeError: Cannot read property 'split' of undefined
```