### PR TITLE
add in missing `Suspense` import

### DIFF
--- a/latest/using-with-hooks.md
+++ b/latest/using-with-hooks.md
@@ -117,7 +117,7 @@ Please note the t function will be either bound to the default namespace defined
 There might be some legacy cases where you still forced to use classes. No worry we still provide a hoc to cover this cases:
 
 ```jsx
-import React, { Component } from 'react';
+import React, { Component, Suspense } from 'react';
 import { withTranslation } from 'react-i18next';
 
 class LegacyComponentClass extends Component {


### PR DESCRIPTION
In addition to this change, we also need to replace `{<Spinner />}` with simply `"loading"`, or put in the correct Spinner import also.  This needs to happen in *both* places where Suspense is used.