### PR TITLE
remove Spinner from Suspense

### DIFF
--- a/latest/using-with-hooks.md
+++ b/latest/using-with-hooks.md
@@ -91,7 +91,7 @@ function MyComponent() {
 // use react's Suspense
 function App() {
   return (
-    <Suspense fallback={<Spinner />}>
+    <Suspense fallback="loading">
       <MyComponent />
     </Suspense>
   );
@@ -135,7 +135,7 @@ const MyComponent = withTranslation()(LegacyComponentClass)
 // use react's Suspense
 function App() {
   return (
-    <Suspense fallback={<Spinner />}>
+    <Suspense fallback="loading">
       <MyComponent />
     </Suspense>
   );


### PR DESCRIPTION
Replace `{<Spinner />}` with simply `"loading"`, or put in the correct Spinner import also. This needs to happen in both places where Suspense is used.

Since the purpose of this tutorial is to **get i18next working with react**, it will be easier for everyone to do away with `<Spinner />` which requires its own import statement (and even with the import statement gives an error in certain situations, making it a barrier to entry).  If people want a nice spinner, I feel like that's a separate issue.

Please note that the tutorial does *not* include the Spinner import statement, so people following the tutorial as-is will *not* end up with a working model.