### PR TITLE
Update migrating-v9-to-v10.md

### DIFF
--- a/latest/migrating-v9-to-v10.md
+++ b/latest/migrating-v9-to-v10.md
@@ -35,6 +35,27 @@ i18n.init({
 });
 ```
 
+## I18nextProvider changes
+
+The `I18nextProvider` does no longer provides as much properties as before. So please make the necessary changes in your codebase after migrating.
+
+```javascript
+// New props
+{
+  i18n,
+  defaultNS,
+}
+
+// Old props
+{
+  i18n,
+  defaultNS,
+  reportNS,
+  lng: i18n && i18n.language,
+  t: i18n && i18n.t.bind(i18n),
+}
+```
+
 ## Components v9 -&gt; v10
 
 | Type | v9 | v10 |


### PR DESCRIPTION
We ran into an issue using `next-i18next` which led us back to a change made in the v10. This PR is to provide documentation for others which want to upgrade.

Issue for reference: https://github.com/isaachinman/next-i18next/issues/348