### PR TITLE
docs: remove legacy react option `wait`

### DIFF
--- a/misc/using-with-icu-format.md
+++ b/misc/using-with-icu-format.md
@@ -41,7 +41,6 @@ i18n
 
     // react i18next special options (optional)
     react: {
-      wait: false,
       bindI18n: 'languageChanged loaded',
       bindStore: 'added removed',
       nsMode: 'default'


### PR DESCRIPTION
`wait` is not a valid option anymore, but still present in this doc.