### PR TITLE
Additional example: children node not possible in simple html elements

### DIFF
--- a/latest/trans-component.md
+++ b/latest/trans-component.md
@@ -70,6 +70,7 @@ but not:
 
 * &lt;i className="icon-gear" /&gt;  
 * &lt;strong title="something"&gt;bold something&lt;/strong&gt;
+* &lt;strong&gt;bold &lt;i&gt;something&lt;/i&gt;&lt;/strong&gt;
 {% endhint %}
 
 It allows you to have basic html tags inside your translations which will get converted to valid react elements:


### PR DESCRIPTION
I had quickly read the documentation and mostly looked at the examples and wasted time trying to understand why my `<p><strong></strong></p>` would generate `<p><0></0></p>`.

Added an example that makes it more obvious