### PR TITLE
Convert tables in documentation to markdown

### DIFF
--- a/book.json
+++ b/book.json
@@ -1,5 +1,5 @@
 {
-    "plugins": [ "addcssjs", "edit-link", "theme-api", "jsfiddle", "custom-favicon", "simple-page-toc", "anchors" ],
+    "plugins": [ "addcssjs", "edit-link", "theme-api", "jsfiddle", "custom-favicon", "simple-page-toc", "anchors", "hints" ],
     "pluginsConfig": {
         "edit-link": {
             "base": "https://github.com/i18next/react-i18next-gitbook/edit/master/",

--- a/latest/i18next-instance.md
+++ b/latest/i18next-instance.md
@@ -43,64 +43,14 @@ export default i18n;
 
 All additional options for react in init options:
 
-<table>
-  <thead>
-    <tr>
-      <th style="text-align:left"><em><b>options</b></em>
-      </th>
-      <th style="text-align:left"><em><b>default</b></em>
-      </th>
-      <th style="text-align:left"><em><b>description</b></em>
-      </th>
-    </tr>
-  </thead>
-  <tbody>
-    <tr>
-      <td style="text-align:left">bindI18n</td>
-      <td style="text-align:left">&apos;languageChanged&apos;</td>
-      <td style="text-align:left">which events trigger a rerender, can be set to false or string of events
-        separated by &quot; &quot;</td>
-    </tr>
-    <tr>
-      <td style="text-align:left">bindI18nStore</td>
-      <td style="text-align:left">&apos;&apos;</td>
-      <td style="text-align:left">define which events on <a href="https://www.i18next.com/overview/api#store-events">resourceStore</a> should
-        trigger a rerender</td>
-    </tr>
-    <tr>
-      <td style="text-align:left">transEmptyNodeValue</td>
-      <td style="text-align:left">&apos;&apos;</td>
-      <td style="text-align:left">how to treat failed lookups in Trans component</td>
-    </tr>
-    <tr>
-      <td style="text-align:left">transSupportBasicHtmlNodes</td>
-      <td style="text-align:left">true</td>
-      <td style="text-align:left">
-        <p>convert eg. &lt;br/&gt; found in translations to a react component of
-          type br</p>
-        <p></p>
-        <p><a href="trans-component.md#using-for-simple-html-elements-in-translations-v-10-4-0">See Trans component</a>
-        </p>
-      </td>
-    </tr>
-    <tr>
-      <td style="text-align:left">transKeepBasicHtmlNodesFor</td>
-      <td style="text-align:left">[&apos;br&apos;, &apos;strong&apos;, &apos;i&apos;, &apos;p&apos;]</td>
-      <td
-      style="text-align:left">
-        <p>Which nodes not to convert in defaultValue generation in the Trans component.</p>
-        <p></p>
-        <p><a href="trans-component.md#using-for-simple-html-elements-in-translations-v-10-4-0">See Trans component</a>
-        </p>
-        </td>
-    </tr>
-    <tr>
-      <td style="text-align:left">useSuspense</td>
-      <td style="text-align:left">true</td>
-      <td style="text-align:left">If using Suspense or not</td>
-    </tr>
-  </tbody>
-</table>
+| options | default | description |
+| :--- | :--- | :--- |
+| bindI18n | 'languageChanged' | which events trigger a rerender, can be set to false or string of events <br /> separated by "" |
+| bindI18nStore | '' | define which events on [resourceStore](https://www.i18next.com/overview/api#store-events) should trigger a rerender |
+| transEmptyNodeValue | '' | how to treat failed lookups in Trans component |
+| transSupportBasicHtmlNodes | true | convert eg. `<br/>` found in translations to a react component of type br <br /> [See Trans component](trans-component.md#using-for-simple-html-elements-in-translations-v-10-4-0) |
+| transKeepBasicHtmlNodesFor | ['br', 'strong', 'i', 'p'] | Which nodes not to convert in defaultValue generation in the Trans component. <br /> [See Trans component](trans-component.md#using-for-simple-html-elements-in-translations-v-10-4-0) |
+| useSuspense | true | If using Suspense or not |
 
 For more initialization options have look at the [docs](https://www.i18next.com/configuration-options.html).
 

--- a/latest/trans-component.md
+++ b/latest/trans-component.md
@@ -257,58 +257,16 @@ Trans.children = [
 
 | _**name**_ | _**type \(default\)**_ | _**description**_ |
 | :--- | :--- | :--- |
-
-
-<table>
-  <thead>
-    <tr>
-      <th style="text-align:left">i18nKey</th>
-      <th style="text-align:left">string (undefined)</th>
-      <th style="text-align:left">
-        <p>is optional if you prefer to use text as keys you can omit that and the
-          translation will be used as a key.</p>
-        <p>can contain the used namespace by prepending it key in form <code>&apos;ns:key&apos;</code>
-        </p>
-      </th>
-    </tr>
-  </thead>
-  <tbody></tbody>
-</table>
-
-| ns | string \(undefined\) | namespace to use |
-| :--- | :--- | :--- |
-
-
-| t | function \(undefined\) | t function to use instead of i18next.t |
-| :--- | :--- | :--- |
-
-
-| count | integer \(undefined\) | optional count if you use a plural |
-| :--- | :--- | :--- |
-
-
-| tOptions | object \(undefined\) | optional options you like to pass to t function call \(eg. context, postProcessor, ...\) |
-| :--- | :--- | :--- |
-
-
-| parent | node \(undefined\) | a component to wrap the content into \(default none, can be globally set on i18next.init\) -&gt; needed for **react &lt; v16** |
-| :--- | :--- | :--- |
-
-
-| i18n | object \(undefined\) | i18next instance to use if not provided |
-| :--- | :--- | :--- |
-
-
-| defaults | string \(undefined\) | use this instead of default content in children \(useful when using ICU\) |
-| :--- | :--- | :--- |
-
-
-| values | object \(undefined\) | interpolation values if not provided in children |
-| :--- | :--- | :--- |
-
-
-| components | array\[nodes\] \(undefined\) | components to interpolate based on index of tag &lt;0&gt;&lt;/0&gt;, ... |
-| :--- | :--- | :--- |
+| i18nKey | string (undefined) | is optional. if you prefer to use text as keys you can omit that and the translation will be used as a key. Can contain the used namespace by prepending it key in form `'ns:key'` |
+| ns | string (undefined) | namespace to use |
+| t | function (undefined) | t function to use instead of i18next.t |
+| count | integer (undefined) | optional count if you use a plural |
+| tOptions | object (undefined) | optional options you like to pass to t function call \(eg. context, postProcessor, ...\) |
+| parent | node (undefined) | a component to wrap the content into \(default none, can be globally set on i18next.init\) -> needed for **react < v16** |
+| i18n | object (undefined) | i18next instance to use if not provided |
+| defaults | string (undefined) | use this instead of default content in children \(useful when using ICU\) |
+| values | object (undefined) | interpolation values if not provided in children |
+| components | array\[nodes\] (undefined) | components to interpolate based on index of tag <0></0>, ... |
 
 
 ```javascript


### PR DESCRIPTION
I had never used i18next before and was reading the documentation with the intention of starting to use it in a new project. Noticed that the table on trans component doc was rendering bad on the website and decided to fix it in the documentation. When looking for examples of how tables are used in other parts of the documentation, saw that i18next instance documentation markdown file had the tabled written in HTML with some extraneous markup, so thought it'd make sense to convert that one to markdown as well.

#### Impact
* Tables in the documentation are rendered correctly and consistently. The attached screenshots show the differences.
* added "hints" plugin to `gitbook.json`. This plugin missing was preventing correct serving of gitbook for local development.

#### Checklist

- [x] only relevant code is changed (make a diff before you submit the PR)
- [ ] run tests `npm run test` *there's no package.json and no tests provided in the repository*
- [ ] tests are included *no testable things were changed*
- [x] documentation is changed or added

#### Addenda
<img width="500" alt="pilt" src="https://user-images.githubusercontent.com/408256/87436028-29f80180-c5f5-11ea-880c-01a20716a682.png">
Trans component props table renders prior to this PR

<img width="500" alt="pilt" src="https://user-images.githubusercontent.com/408256/87436162-56138280-c5f5-11ea-9d75-6cd14461ae37.png">
Trans component props table after this PR