### PR TITLE
Fix typo in ICU format documentation

### DIFF
--- a/misc/using-with-icu-format.md
+++ b/misc/using-with-icu-format.md
@@ -1,6 +1,6 @@
 # Using with ICU format
 
-i18next itself is flexible enough to support multiple existing i18next formats beside it's own.
+i18next itself is flexible enough to support multiple existing i18next formats beside its own.
 
 {% hint style="info" %}
 Find the full working sample here:


### PR DESCRIPTION
Fix grammatical error by removing incorrect apostrophe.