### PR TITLE
next-i18next works in Serverless mode so update docs.

### DIFF
--- a/latest/ssr.md
+++ b/latest/ssr.md
@@ -4,7 +4,7 @@
 
 You should have a look at [next-i18next](https://github.com/isaachinman/next-i18next) which extends react-i18next to bring it to next.js the easiest way.
 
-> `next-i18next` does not yet support Next.js in [**Serverless** mode](https://nextjs.org/blog/next-8#serverless-nextjs) \(as of March 2020\). If your goal is to use Next.js with Serverless, then you should have a look at ["Next Right Now"](https://github.com/UnlyEd/next-right-now), which is a Next.js 9 boilerplate with built-in `i18next`, `react-i18next` and Locize.
+> `next-i18next@v5.0.0` supports `Next.js v9.5` in [**Serverless** mode](https://nextjs.org/blog/next-8#serverless-nextjs) \(as of [July 2020](https://github.com/isaachinman/next-i18next/issues/274#issuecomment-664616304)\). If your goal is to use earlier versions of Next.js with Serverless, then you should have a look at ["Next Right Now"](https://github.com/UnlyEd/next-right-now), which is a Next.js 9 boilerplate with built-in `i18next`, `react-i18next` and Locize.
 
 ## Setting the i18next instance based on req
 


### PR DESCRIPTION
Update the docs to specify the minimum versions of `next-i18next` (v5) and `Next.js` (v9.5) to work in Serverless mode .