### PR TITLE
Update testing.md

### DIFF
--- a/misc/testing.md
+++ b/misc/testing.md
@@ -40,6 +40,22 @@ jest.mock('react-i18next', () => ({
 }));
 ```
 
+Or, when using the `useTranslation` hook instead of `withTranslation`, mock it like:
+
+```javascript
+jest.mock('react-i18next', () => ({
+  // this mock makes sure any components using the translate hook can use it without a warning being shown
+  useTranslation: () => {
+    return {
+      t: (str) => str,
+      i18n: {
+        changeLanguage: () => new Promise(() => {}),
+      },
+    };
+  },
+}));
+```
+
 {% hint style="success" %}
 You can find a full sample for testing with jest here: [https://github.com/i18next/react-i18next/tree/master/example/test-jest](https://github.com/i18next/react-i18next/tree/master/example/test-jest)
 {% endhint %}


### PR DESCRIPTION
Add an example for mocking the `useTranslation` hook.

I think it would be nice if the documentation directly states an example of how to mock the `useTranslation` hook with jest. When the hook is not mocked, the console shows following warning:


```javascript
console.warn
    react-i18next:: You will need to pass in an i18next instance by using initReactI18next

       9 | 
      10 | function App() {
    > 11 |   const { t } = useTranslation();
         |                 ^
      12 | 
      13 |   /**
      14 |    * This is an example function in arrow notation and with typed JSDoc.

      at warn (node_modules/react-i18next/dist/commonjs/utils.js:22:31)
      at warnOnce (node_modules/react-i18next/dist/commonjs/utils.js:35:8)
      at useTranslation (node_modules/react-i18next/dist/commonjs/useTranslation.js:36:25)
      at App (src/pages/App/App.jsx:11:17)
      at renderWithHooks (node_modules/react-dom/cjs/react-dom.development.js:14985:18)
      at mountIndeterminateComponent (node_modules/react-dom/cjs/react-dom.development.js:17811:13)
      at beginWork (node_modules/react-dom/cjs/react-dom.development.js:19049:16)
```

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.
-->

#### Checklist

- [ ] only relevant code is changed (make a diff before you submit the PR)
- [ ] run tests `npm run test`
- [ ] tests are included
- [x] documentation is changed or added