### PR TITLE
Remove "newly" from Trans Component documentation

### DIFF
--- a/latest/trans-component.md
+++ b/latest/trans-component.md
@@ -111,7 +111,7 @@ Existing self-closing HTML tag names are reserved keys. `link: <Link />`, `img: 
 ### Using for &lt;br /&gt; and other simple html elements in translations \(v10.4.0\)
 
 {% hint style="info" %}
-This was newly added in react-i18next@**v10.4.0**
+This was added in react-i18next@**v10.4.0**
 
 Allows elements not having additional attributes like className and only no children \(void\) or one text child:
 


### PR DESCRIPTION
It says newly but references v10.4.0 and v20+ is out. 