### PR TITLE
chore: update code example to remove hardcoded lng

### DIFF
--- a/legacy-v9/step-by-step-guide.md
+++ b/legacy-v9/step-by-step-guide.md
@@ -162,7 +162,6 @@ i18n
   .use(reactI18nextModule) // passes i18n down to react-i18next
   .init({
     resources,
-    lng: "en",
     fallbackLng: "en", // use en if detected lng is not available
 
     keySeparator: false, // we do not use keys in form messages.welcome


### PR DESCRIPTION
- the language is being detected, but not used if the lng is hardcoded. Code example should show working solution.

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.
-->

#### Checklist

- [x] only relevant code is changed (make a diff before you submit the PR)
- [ ] run tests `npm run test`
- [ ] tests are included
- [ ] documentation is changed or added

Based on a [conversation from 2019](https://github.com/i18next/i18next-browser-languageDetector/issues/183#issuecomment-520129030) the code example in the guide does not work since it hard codes the lng instead of using the language detector. This PR updates the docs to an out-of-the-box working solution to avoid confusion.