### PR TITLE
Add TypeScript instructions for classes to the withTranslation HOC doc page

### DIFF
--- a/latest/withtranslation-hoc.md
+++ b/latest/withtranslation-hoc.md
@@ -138,7 +138,7 @@ import { withTranslation, WithTranslation } from 'react-i18next';
 
 class MyComponent extends Component<IProps, IState> {
   render() {
-    return <div>{this.props.t('My translated text')}</p>
+    return <div>{this.props.t('My translated text')}</div>
   }
 }
 

--- a/latest/withtranslation-hoc.md
+++ b/latest/withtranslation-hoc.md
@@ -128,3 +128,27 @@ Extended.static = MyComponent.static;
 export default Extended;
 ```
 
+### use TypeScript with class components
+
+To get proper type annotations while using TypeScript, import the interface `WithTranslation` and extend it with your own props interface.
+
+```tsx
+import React, { Component } from 'react';
+import { withTranslation, WithTranslation } from 'react-i18next';
+
+class MyComponent extends Component<IProps, IState> {
+  render() {
+    return <div>{this.props.t('My translated text')}</p>
+  }
+}
+
+interface IProps extends WithTranslation {
+  prop: any;
+}
+
+interface IState {
+  state: any;
+}
+
+export default withTranslation()(MyComponent);
+```


### PR DESCRIPTION
<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.
-->

#### Checklist

- [ ] only relevant code is changed (make a diff before you submit the PR)
- [ ] run tests `npm run test`
- [ ] tests are included
- [x] documentation is changed or added

I'm working with `react-i18next` in my current project, which uses TypeScript and a lot of class components. I noticed that there was no information in the documentation that I could easily find on getting proper type information, so I figured adding it to the documentation would potentially be appreciated.