### PR TITLE
Clarify some passages

### DIFF
--- a/latest/trans-component.md
+++ b/latest/trans-component.md
@@ -88,7 +88,8 @@ _Your en.json \(translation strings\) will look like:_
 ```
 
 {% hint style="info" %}
-[**saveMissing**](https://www.i18next.com/overview/configuration-options#missing-keys) will send a valid defaultValue
+[**saveMissing**](https://www.i18next.com/overview/configuration-options#missing-keys) will send a valid `defaultValue`.  
+Also, The `i18nKey` is optional, in case you already use text as translation keys.
 {% endhint %}
 
 ### Alternative usage \(v11.6.0\)
@@ -185,14 +186,14 @@ You can use i18next.options.react to adapt this behaviour:
 
 ### Interpolation
 
-You can pass in variables to get interpolated into the translation string by passing down objects in node children containing those key:values.
+You can pass in variables to get interpolated into the translation string by using objects containing those key:values.
 
 ```jsx
 const person = { name: 'Henry', age: 21 };
 const { name, age } = person;
 
 <Trans>
-  Hello {{ name }}. // <- = {{ name: name }}
+  Hello {{ name }}. // <- = {{ "name": name }}
 </Trans>
 // Translation string: "Hello {{name}}"
 
@@ -221,7 +222,7 @@ const messages = ['message one', 'message two'];
 
 ### Using with lists \(v10.5.0\)
 
-You can use list.map as children. Mapping dynamic content.
+You can still use Array.map as children, to map dynamic content into components, using an extra option on the wrapper:
 
 ```jsx
 <Trans i18nKey="list_map">
@@ -237,7 +238,7 @@ Setting `i18nIsDynamicList` on the wrapping element will assert the nodeToString
 
 ### Alternative usage \(components array\)
 
-Some use cases might be simpler by just passing content as props:
+Some use cases, such as the ICU format, might be simpler by just passing content as props:
 
 ```javascript
 <Trans
@@ -252,7 +253,7 @@ Some use cases might be simpler by just passing content as props:
 `<0>` -&gt; 0 is the index of the component in the components array
 {% endhint %}
 
-Eg. this format is needed when using [ICU as translation format](https://github.com/i18next/i18next-icu) as it is not possible to have the needed syntax as children \(invalid jsx\).
+E.g. this format is needed when using [ICU as translation format](https://github.com/i18next/i18next-icu) as it is not possible to have the needed syntax as children \(invalid jsx\).
 
 ## How to get the correct translation string?
 
@@ -293,9 +294,9 @@ Trans.children = [
 
 **Rules:**
 
-* child is a string =&gt; nothing to wrap just take the string  
-* child is an object =&gt; nothing to do it's used for interpolation  
-* child is an element: wrap it's children in &lt;i&gt;&lt;/i&gt; where i is the index of that element position in children and handle it's children with same rules \(starting element.children index at 0 again\)
+* child is a string: nothing to wrap; just take the string  
+* child is an object: nothing to do; it's used for interpolation  
+* child is an element: wrap it's children in `<x></x>` where `x` is the index of that element's position in the `children` list; handle its children with the same rules \(starting `element.children` index at 0 again\)
 
 ## Trans props
 


### PR DESCRIPTION
From first reading that doc page, I noticed several confusing passages that, after re-re-reading, I (think) I was able to understand. Thus, I'm sending this PR to help out the next adventurers :)

> Turns out I ended up taking more time (double-ish?) editing the file and writing this PR than actually reading the related docs page :sweat_smile: 

There are some things I wasn't able to solve and include without deeper changes/understanding, though:
- it got confusing on whether tags will be indexed or string-named; I understand there's an option to skip indexing simple tags (such as `<br/>` or `<i>`), but it's confusing until you get past the middle. For instance, the "Alternative usage (v11.6.0)" makes it seem like you _need_ to re-map your tags if you want the final text to have meaningful tags. The next section still doesn't make it clear if that can be automated or not, it's just clear at the "i18n options" section at the very bottom.
- `saveMissing` is mentioned a bunch of times, but it meant nothing for me since I skipped the config of i18next for now (I'm trying to understand how it all works together before digging into config files). That said, there _is_ a section on i18next options at the end, but that one isn't mentioned. If it gets added, I would suggest changing its link into the internal anchor instead of the external i18next docs. And... even after reading what `saveMissing` is, it didn't make much sense for me what's the direct relationship with `Trans`?
- aren't all props optional? Some seem to be marked as such (with no standard), but most aren't; yet, some examples show no props at all.
- bonus: is that PR checklist valid for a docs repository? :thinking: 

Also, there's a lot of confusing formatting chosen for these docs, and I'm not sure what's intentional, what was caused by simple rushed writing, and what's accidental. This might be common throughout i18n docs, but I saw it mainly on this page and that's why I'm pointing it here:
- _lots_ of places mentioning code without code fences (such as: "wrap it's children in <i></i> where i is the index"). I guess another side effect of this (besides being harder to follow some sentences) is that the source is also hard to edit since there are a _lot_ of HTML entities all over
- why are all parentheses escaped in Markdown? Is that a Gitbook thing? :thinking: 

#### Checklist

- [x] only relevant code is changed (make a diff before you submit the PR) *(could also just suggest reading the diff below the PR before creating it)*
- [ ] run tests `npm run test`
- [ ] tests are included
- [ ] documentation is changed or added