### PR TITLE
fix(trans-component.md): add missing space character typo

### DIFF
--- a/latest/trans-component.md
+++ b/latest/trans-component.md
@@ -242,7 +242,7 @@ Guessing replacement tags _(<0>\</0>)_ of your component is rather difficult. Th
 Trans.children = [
   'Hello ',                         // 0: only a string
   { children: [{ name: 'Jan' }] },  // 1: <strong> with child object for interpolation
-  ', you have',                     // 2: only a string
+  ', you have ',                    // 2: only a string
   { count: 10 },                    // 3: plain object for interpolation
   ' unread messages. ',             // 4: only a string
   { children: ['Go to messages'] }, // 5: <Link> with a string child


### PR DESCRIPTION
<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.
-->

Fixed a typo in `<Trans>` component https://react.i18next.com/latest/trans-component#how-to-get-the-correct-translation-string children array.

#### Checklist

- [x] only relevant code is changed
- [ ] run tests `npm run test`
- [ ] tests are included (None)

#### Checklist (for documentation change)

- [x] only relevant documentation part is changed (make a diff before you submit the PR)
- [ ] motivation/reason is provided