### PR TITLE
prevent confusions with the default namespace

### DIFF
--- a/misc/testing.md
+++ b/misc/testing.md
@@ -77,8 +77,8 @@ i18n
     fallbackLng: 'en',
 
     // have a common namespace used around the full app
-    ns: ['translations'],
-    defaultNS: 'translations',
+    ns: ['translationsNS'],
+    defaultNS: 'translationsNS',
 
     debug: true,
 
@@ -86,7 +86,7 @@ i18n
       escapeValue: false, // not needed for react!!
     },
 
-    resources: { en: { translations: {} } },
+    resources: { en: { translationsNS: {} } },
   });
 
 export default i18n;


### PR DESCRIPTION
Make clear to the users that `translationsNS` is the namespace name and it is the name that schuld be used in `resources: { en: { translationsNS: {} } },` . This prevents confusions with the default namespace `translation`.

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.
-->

#### Checklist

- [ ] only relevant code is changed (make a diff before you submit the PR)
- [ ] run tests `npm run test`
- [ ] tests are included

#### Checklist (for documentation change)

- [x] only relevant documentation part is changed (make a diff before you submit the PR)
- [x] motivation/reason is provided