### PR TITLE
Adapt mock needed when using `useTranslation`

### DIFF
--- a/misc/testing.md
+++ b/misc/testing.md
@@ -53,6 +53,10 @@ jest.mock('react-i18next', () => ({
       },
     };
   },
+  initReactI18next: {
+    type: '3rdParty',
+    init: () => {},
+  }
 }));
 ```
 
@@ -76,6 +80,10 @@ import { useTranslation } from 'react-i18next';
 
 jest.mock('react-i18next', () => ({
   useTranslation: jest.fn(),
+  initReactI18next: {
+    type: '3rdParty',
+    init: jest.fn(),
+  }
 }));
 
 const tSpy = jest.fn((str) => str);


### PR DESCRIPTION
When testing a React app that uses `i18next` and `react-i18next` with `vite` the mock in the documentation wasn't sufficient for me but I also needed to add `initReactI18next`.

Thanks for maintaining this project!

#### Checklist (for documentation change)

- [x] only relevant documentation part is changed (make a diff before you submit the PR)
- [x] motivation/reason is provided
- [x] commit message and code follows the [Developer's Certification of Origin](https://github.com/i18next/.github/blob/master/CONTRIBUTING.md)