### PR TITLE
Add missing `values` prop in `Trans`

### DIFF
--- a/latest/trans-component.md
+++ b/latest/trans-component.md
@@ -69,7 +69,7 @@ function MyComponent({ person, messages }) {
   const count = messages.length;
 
   return (
-    <Trans i18nKey="userMessagesUnread" count={count}>
+    <Trans i18nKey="userMessagesUnread" values={{ name, count}}>
       Hello <strong title={t('nameTitle')}>{{name}}</strong>, you have {{count}} unread message. <Link to="/msgs">Go to messages</Link>.
     </Trans>
   );


### PR DESCRIPTION
Hi

I think the documentation is not correct as when I tried passing the values with `<Trans count=count>` it didn't work. Looks like they need to be passed in `values`.

Also it would have been nice to have links to this github repo from the documentation, if you want to get more such contributions.

Thanks!

#### Checklist (for documentation change)

- [x] only relevant documentation part is changed (make a diff before you submit the PR)
- [x] motivation/reason is provided
- [x] commit message and code follows the [Developer's Certification of Origin](https://github.com/i18next/.github/blob/master/CONTRIBUTING.md)