### PR TITLE
Documents new selector API

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,6 +76,8 @@ Then [this article](https://www.locize.com/blog/i18n-next-app-router) is what yo
 
 **After:** With the `Trans` component just change it to:
 
+{% tabs %}
+{% tab title="JavaScript" %}
 ```jsx
 ...
 <div>{t('simpleContent')}</div>
@@ -84,6 +86,19 @@ Then [this article](https://www.locize.com/blog/i18n-next-app-router) is what yo
 </Trans>
 ...
 ```
+{% endtab %}
+
+{% tab title="TypeScript" %}
+```tsx
+...
+<div>{t($ => $.simpleContent)}</div>
+<Trans i18nKey="userMessagesUnread" count={count}>
+  Hello <strong title={t($ => $.nameTitle)}>{{name}}</strong>, you have {{count}} unread message(s). <Link to="/msgs">Go to messages</Link>.
+</Trans>
+...
+```
+{% endtab %}
+{% endtabs %}
 
 If you prefer not using semantic keys but text - [that's also possible](https://www.i18next.com/principles/fallback.html#key-fallback).
 

--- a/getting-started.md
+++ b/getting-started.md
@@ -46,9 +46,19 @@ Simple content can easily be translated using the provided `t` function.
 
 **After:**
 
+{% tabs %}
+{% tab title="JavaScript" %}
 ```jsx
 <div>{t('simpleContent')}</div>
 ```
+{% endtab %}
+
+{% tab title="TypeScript" %}
+```tsx
+<div>{t($ => $.simpleContent)}</div>
+```
+{% endtab %}
+{% endtabs %}
 
 {% hint style="info" %}
 You will get the t function by using the [useTranslation](latest/usetranslation-hook.md) hook or the [withTranslation](latest/withtranslation-hoc.md) hoc.
@@ -74,6 +84,24 @@ Sometimes you might want to include html formatting or components like links int
 </Trans>
 ```
 
+{% tabs %}
+{% tab title="JavaScript" %}
+```
+<Trans i18nKey="userMessagesUnread" count={count}>
+  Hello <strong title={t('nameTitle')}>{{name}}</strong>, you have {{count}} unread message. <Link to="/msgs">Go to messages</Link>.
+</Trans>
+```
+{% endtab %}
+
+{% tab title="TypeScript" %}
+```
+<Trans i18nKey="userMessagesUnread" count={count}>
+  Hello <strong title={t('nameTitle')}>{{name}}</strong>, you have {{count}} unread message. <Link to="/msgs">Go to messages</Link>.
+</Trans>
+```
+{% endtab %}
+{% endtabs %}
+
 {% hint style="info" %}
 Learn more about the Trans Component [here](latest/trans-component.md)
 {% endhint %}
@@ -82,7 +110,9 @@ Learn more about the Trans Component [here](latest/trans-component.md)
 
 This basic sample tries to add i18n in a one file sample.
 
-```javascript
+{% tabs %}
+{% tab title="JavaScript" %}
+```jsx
 import React from "react";
 import { createRoot } from 'react-dom/client';
 import i18n from "i18next";
@@ -121,6 +151,50 @@ root.render(
   <App />
 );
 ```
+{% endtab %}
+
+{% tab title="TypeScript" %}
+```tsx
+import React from "react";
+import { createRoot } from 'react-dom/client';
+import i18n from "i18next";
+import { useTranslation, initReactI18next } from "react-i18next";
+
+i18n
+  .use(initReactI18next) // passes i18n down to react-i18next
+  .init({
+    // the translations
+    // (tip move them in a JSON file and import them,
+    // or even better, manage them via a UI: https://react.i18next.com/guides/multiple-translation-files#manage-your-translations-with-a-management-gui)
+    resources: {
+      en: {
+        translation: {
+          "Welcome to React": "Welcome to React and react-i18next"
+        }
+      }
+    },
+    lng: "en", // if you're using a language detector, do not define the lng option
+    fallbackLng: "en",
+
+    interpolation: {
+      escapeValue: false // react already safes from xss => https://www.i18next.com/translation-function/interpolation#unescape
+    }
+  });
+
+function App() {
+  const { t } = useTranslation();
+
+  return <h2>{t($ => $['Welcome to React'])}</h2>;
+}
+
+// append app to dom
+const root = createRoot(document.getElementById('root'));
+root.render(
+  <App />
+);
+```
+{% endtab %}
+{% endtabs %}
 
 #### RESULT:
 

--- a/getting-started.md
+++ b/getting-started.md
@@ -96,7 +96,7 @@ Sometimes you might want to include html formatting or components like links int
 {% tab title="TypeScript" %}
 ```
 <Trans i18nKey="userMessagesUnread" count={count}>
-  Hello <strong title={t('nameTitle')}>{{name}}</strong>, you have {{count}} unread message. <Link to="/msgs">Go to messages</Link>.
+  Hello <strong title={t($ => $.nameTitle)}>{{name}}</strong>, you have {{count}} unread message. <Link to="/msgs">Go to messages</Link>.
 </Trans>
 ```
 {% endtab %}

--- a/guides/multiple-translation-files.md
+++ b/guides/multiple-translation-files.md
@@ -4,17 +4,37 @@ One of the advantages of react-i18next is based on i18next it supports the separ
 
 So while this takes the translation from the defined default namespace:
 
-```javascript
+{% tabs %}
+{% tab title="JavaScript" %}
+```jsx
 i18next.t('look.deep');
 ```
+{% endtab %}
+
+{% tab title="TypeScript" %}
+```tsx
+i18next.t($ => $.look.deep);
+```
+{% endtab %}
+{% endtabs %}
 
 This will lookup the key in a namespace (file) called common.json:
 
-```javascript
+{% tabs %}
+{% tab title="JavaScript" %}
+```jsx
 i18next.t('common:look.deep'); // not recommended with ns prefix when used in combination with natural language keys
 // better use the ns option:
 i18next.t('look.deep', { ns: 'common' })
 ```
+{% endtab %}
+
+{% tab title="TypeScript" %}
+```tsx
+i18next.t($ => $.look.deep, { ns: 'common' })
+```
+{% endtab %}
+{% endtabs %}
 
 In order to use multiple namespaces/translation files, you need to specify it when calling [`useTranslation`](https://react.i18next.com/latest/usetranslation-hook) :
 
@@ -30,13 +50,27 @@ withTranslation(['translation', 'common'])(MyComponent);
 
 or [`Translation`](https://react.i18next.com/latest/translation-render-prop):
 
-```javascript
+{% tabs %}
+{% tab title="JavaScript" %}
+```jsx
 <Translation ns={['translation', 'common']}>
 {
   (t) => <p>{t('look.deep', { ns: 'common' })}</p>
 }
 </Translation>
 ```
+{% endtab %}
+
+{% tab title="TypeScript" %}
+```tsx
+<Translation ns={['translation', 'common']}>
+{
+  (t) => <p>{t($ => $.look.deep, { ns: 'common' })}</p>
+}
+</Translation>
+```
+{% endtab %}
+{% endtabs %}
 
 ## Separating translation files
 
@@ -65,4 +99,3 @@ There's also the possibility to have an [even more focused developer experience]
 {% embed url="https://youtu.be/osScyaGMVqo" %}
 
 {% embed url="https://youtu.be/VfxBpSXarlU" %}
-

--- a/guides/quick-start.md
+++ b/guides/quick-start.md
@@ -106,7 +106,7 @@ If you need to access the `t` function or the `i18next` instance from outside of
 
 <pre><code><strong>import i18next from './i18n'
 </strong>
-i18next.t($ => $['my.key'])
+i18next.t($ => $.my.key)
 </code></pre>
 
 \

--- a/guides/quick-start.md
+++ b/guides/quick-start.md
@@ -85,6 +85,8 @@ root.render(
 );
 ```
 
+{% tabs %}
+{% tab title="JavaScript" %}
 {% hint style="info" %}
 If you need to access the `t` function or the `i18next` instance from outside of a React component you can simply import your `./i18n.js` and use the exported i18next instance:
 
@@ -96,6 +98,22 @@ i18next.t('my.key')
 \
 Also read about this [here](https://www.locize.com/blog/how-to-use-i18next-t-outside-react-components) and [here](https://github.com/i18next/react-i18next/issues/1236#issuecomment-762039023).
 {% endhint %}
+{% endtab %}
+
+{% tab title="TypeScript" %}
+{% hint style="info" %}
+If you need to access the `t` function or the `i18next` instance from outside of a React component you can simply import your `./i18n.js` and use the exported i18next instance:
+
+<pre><code><strong>import i18next from './i18n'
+</strong>
+i18next.t($ => $['my.key'])
+</code></pre>
+
+\
+Also read about this [here](https://www.locize.com/blog/how-to-use-i18next-t-outside-react-components) and [here](https://github.com/i18next/react-i18next/issues/1236#issuecomment-762039023).
+{% endhint %}
+{% endtab %}
+{% endtabs %}
 
 ## Translate your content
 
@@ -105,6 +123,8 @@ Using the hook in functional components is one of the options you have.
 
 The `t` function is the main function in i18next to translate content. Read the [documentation](https://www.i18next.com/translation-function/essentials) for all the options.
 
+{% tabs %}
+{% tab title="JavaScript" %}
 ```jsx
 import React from 'react';
 
@@ -116,6 +136,22 @@ function MyComponent () {
   return <h1>{t('Welcome to React')}</h1>
 }
 ```
+{% endtab %}
+
+{% tab title="TypeScript" %}
+```tsx
+import React from 'react';
+
+// the hook
+import { useTranslation } from 'react-i18next';
+
+function MyComponent () {
+  const { t, i18n } = useTranslation();
+  return <h1>{t($ => $['Welcome to React'])}</h1>
+}
+```
+{% endtab %}
+{% endtabs %}
 
 Learn more about the hook [useTranslation](../latest/usetranslation-hook.md).
 
@@ -125,6 +161,8 @@ Using higher order components is one of the most used method to extend existing 
 
 The `t` function is the main function in i18next to translate content. Read the [documentation](https://www.i18next.com/translation-function/essentials) for all the options.
 
+{% tabs %}
+{% tab title="JavaScript" %}
 ```jsx
 import React from 'react';
 
@@ -137,6 +175,23 @@ function MyComponent ({ t }) {
 
 export default withTranslation()(MyComponent);
 ```
+{% endtab %}
+
+{% tab title="TypeScript" %}
+```tsx
+import React from 'react';
+
+// the hoc
+import { withTranslation } from 'react-i18next';
+
+function MyComponent ({ t }) {
+  return <h1>{t($ => $['Welcome to React'])}</h1>
+}
+
+export default withTranslation()(MyComponent);
+```
+{% endtab %}
+{% endtabs %}
 
 Learn more about the higher order component [withTranslation](../latest/withtranslation-hoc.md).
 
@@ -144,6 +199,8 @@ Learn more about the higher order component [withTranslation](../latest/withtran
 
 The render prop enables you to use the `t` function inside your component.
 
+{% tabs %}
+{% tab title="JavaScript" %}
 ```jsx
 import React from 'react';
 
@@ -160,6 +217,27 @@ export default function MyComponent () {
   )
 }
 ```
+{% endtab %}
+
+{% tab title="TypeScript" %}
+```tsx
+import React from 'react';
+
+// the render prop
+import { Translation } from 'react-i18next';
+
+export default function MyComponent () {
+  return (
+    <Translation>
+      {
+        t => <h1>{t($ => $['Welcome to React'])}</h1>
+      }
+    </Translation>
+  )
+}
+```
+{% endtab %}
+{% endtabs %}
 
 Learn more about the render prop [Translation](../latest/translation-render-prop.md).
 

--- a/guides/the-drawbacks-of-other-i18n-solutions.md
+++ b/guides/the-drawbacks-of-other-i18n-solutions.md
@@ -4,7 +4,9 @@ Let's make the sample using our own base i18n framework [i18next](https://i18nex
 
 ## Using a pure javascript i18n framework
 
-```javascript
+{% tabs %}
+{% tab title="JavaScript" %}
+```jsx
 import React, { Component } from "react";
 import { createRoot } from 'react-dom/client';
 import i18n from "i18next";
@@ -36,6 +38,43 @@ root.render(
   <App />
 );
 ```
+{% endtab %}
+
+{% tab title="TypeScript" %}
+```tsx
+import React, { Component } from "react";
+import { createRoot } from 'react-dom/client';
+import i18n from "i18next";
+
+// translation catalog
+const resources = {
+  en: {
+    translation: {
+      "welcome": "Welcome to React and react-i18next"
+    }
+  }
+};
+
+// initialize i18next with catalog and language to use
+i18n.init({
+  resources,
+  lng: "en"
+});
+
+class App extends Component {
+  render() {
+    return <h2>{i18n.t($ => $.welcome)}</h2>;
+  }
+}
+
+// append app to dom
+const root = createRoot(document.getElementById('root'));
+root.render(
+  <App />
+);
+```
+{% endtab %}
+{% endtabs %}
 
 ## More react adapted "react-i18n"
 

--- a/latest/trans-component.md
+++ b/latest/trans-component.md
@@ -61,7 +61,9 @@ function MyComponent({ person, messages }) {
 
 **After:** With the Trans component just change it to:
 
-```javascript
+{% tabs %}
+{% tab title="JavaScript" %}
+```jsx
 import { Trans } from 'react-i18next';
 
 function MyComponent({ person, messages }) {
@@ -75,6 +77,25 @@ function MyComponent({ person, messages }) {
   );
 }
 ```
+{% endtab %}
+
+{% tab title="TypeScript" %}
+```tsx
+import { Trans } from 'react-i18next';
+
+function MyComponent({ person, messages }) {
+  const { name } = person;
+  const count = messages.length;
+
+  return (
+    <Trans i18nKey="userMessagesUnread" count={count}>
+      Hello <strong title={t($ => $.nameTitle)}>{{name}}</strong>, you have {{count}} unread message. <Link to="/msgs">Go to messages</Link>.
+    </Trans>
+  );
+}
+```
+{% endtab %}
+{% endtabs %}
 
 _Your en.json (translation strings) will look like:_
 
@@ -272,11 +293,23 @@ Guessing replacement tags _(<0>\</0>)_ of your component is rather difficult. Th
 
 **Sample JSX:**
 
-```javascript
+{% tabs %}
+{% tab title="JavaScript" %}
+```jsx
 <Trans i18nKey="userMessagesUnread" count={count}>
     Hello <strong title={t('nameTitle')}>{{name}}</strong>, you have {{count}} unread message. <Link to="/msgs">Go to messages</Link>.
 </Trans>
 ```
+{% endtab %}
+
+{% tab title="TypeScript" %}
+```tsx
+<Trans i18nKey="userMessagesUnread" count={count}>
+    Hello <strong title={t($ => $.nameTitle)}>{{name}}</strong>, you have {{count}} unread message. <Link to="/msgs">Go to messages</Link>.
+</Trans>
+```
+{% endtab %}
+{% endtabs %}
 
 **Resulting translation string:**
 

--- a/latest/translation-render-prop.md
+++ b/latest/translation-render-prop.md
@@ -1,9 +1,11 @@
 # Translation (render prop)
 
-## What it does <a href="what-it-does" id="what-it-does"></a>
+## What it does <a href="#what-it-does" id="what-it-does"></a>
 
 The `Translation` is a render prop and gets the `t` function and `i18n` instance to your component.
 
+{% tabs %}
+{% tab title="JavaScript" %}
 ```jsx
 import React from 'react';
 import { Translation } from 'react-i18next';
@@ -18,6 +20,25 @@ export function MyComponent() {
   )
 }
 ```
+{% endtab %}
+
+{% tab title="TypeScript" %}
+```tsx
+import React from 'react';
+import { Translation } from 'react-i18next';
+
+export function MyComponent() {
+  return (
+    <Translation>
+      {
+        (t, { i18n }) => <p>{t($ => $['my translated text'])}</p>
+      }
+    </Translation>
+  )
+}
+```
+{% endtab %}
+{% endtabs %}
 
 While you most time only need the t function to translate your content you also get the i18n instance to eg. change the language.
 
@@ -31,12 +52,14 @@ The `Translation` render prop will trigger a [Suspense](https://reactjs.org/docs
 
 ## When to use?
 
-Use the `Translation` render prop inside **any component (class or function)** to access the translation function or i18n instance. 
+Use the `Translation` render prop inside **any component (class or function)** to access the translation function or i18n instance.
 
 ## Translation params
 
 ### Loading namespaces
 
+{% tabs %}
+{% tab title="JavaScript" %}
 ```jsx
 // load a specific namespace
 // the t function will be set to that namespace as default
@@ -54,9 +77,33 @@ Use the `Translation` render prop inside **any component (class or function)** t
 }
 </Translation>
 ```
+{% endtab %}
+
+{% tab title="TypeScript" %}
+```tsx
+// load a specific namespace
+// the t function will be set to that namespace as default
+<Translation ns="ns1">
+{
+  (t) => <p>{t($ => $['my translated text'])}</p> // will be looked up from namespace ns1
+}
+</Translation>
+
+// load multiple namespaces
+// the t function will be set to first namespace as default
+<Translation ns={['ns1', 'ns2', 'ns3']}>
+{
+  (t) => <p>{t($ => $['my translated text'])}</p> // will be looked up from namespace ns1
+}
+</Translation>
+```
+{% endtab %}
+{% endtabs %}
 
 ### Overriding the i18next instance
 
+{% tabs %}
+{% tab title="JavaScript" %}
 ```jsx
 // passing in an i18n instance
 // use only if you do not like the default instance
@@ -69,4 +116,20 @@ import i18n from './i18n';
 }
 </Translation>
 ```
+{% endtab %}
 
+{% tab title="TypeScript" %}
+```tsx
+// passing in an i18n instance
+// use only if you do not like the default instance
+// set by i18next.use(initReactI18next) or the I18nextProvider
+import i18n from './i18n';
+
+<Translation i18n={i18n}>
+{
+  (t, { i18n }) => <p>{t($ => $['my translated text'])}</p> // will be looked up from namespace ns1
+}
+</Translation>
+```
+{% endtab %}
+{% endtabs %}

--- a/latest/usetranslation-hook.md
+++ b/latest/usetranslation-hook.md
@@ -166,7 +166,7 @@ i.e.
 
 ```javascript
 const { t } = useTranslation('translation', { keyPrefix: 'very.deeply.nested' });
-const text = t($ => $.ns.key); // this will not work
+const text = t($ => $.key, { ns: 'ns' }); // this will not work
 ```
 {% endhint %}
 {% endtab %}

--- a/latest/usetranslation-hook.md
+++ b/latest/usetranslation-hook.md
@@ -4,6 +4,8 @@
 
 It gets the `t` function and `i18n` instance inside your functional component.
 
+{% tabs %}
+{% tab title="JavaScript" %}
 ```jsx
 import React from 'react';
 import { useTranslation } from 'react-i18next';
@@ -15,6 +17,22 @@ export function MyComponent() {
   return <p>{t('my translated text')}</p>
 }
 ```
+{% endtab %}
+
+{% tab title="TypeScript" %}
+```tsx
+import React from 'react';
+import { useTranslation } from 'react-i18next';
+
+export function MyComponent() {
+  const { t, i18n } = useTranslation(); // not passing any namespace will use the defaultNS (by default set to 'translation')
+  // or const [t, i18n] = useTranslation();
+
+  return <p>{t($ => $['my translated text'])}</p>
+}
+```
+{% endtab %}
+{% endtabs %}
 
 While most of the time you only need the `t` function to translate your content, you can also get the i18n instance (in order to change the language).
 
@@ -41,7 +59,23 @@ You'll also see how to use it when you need to work with [multiple namespaces](h
 
 ### Loading namespaces
 
-```javascript
+{% tabs %}
+{% tab title="JavaScript" %}
+<pre class="language-jsx"><code class="lang-jsx"><strong>// load a specific namespace
+</strong><strong>// the t function will be set to that namespace as default
+</strong>const { t, i18n } = useTranslation('ns1');
+t('key'); // will be looked up from namespace ns1
+
+// load multiple namespaces
+// the t function will be set to first namespace as default
+const { t, i18n } = useTranslation(['ns1', 'ns2', 'ns3']);
+t('key'); // will be looked up from namespace ns1
+t('key', { ns: 'ns2' }); // will be looked up from namespace ns2
+</code></pre>
+{% endtab %}
+
+{% tab title="TypeScript" %}
+```tsx
 // load a specific namespace
 // the t function will be set to that namespace as default
 const { t, i18n } = useTranslation('ns1');
@@ -50,9 +84,11 @@ t('key'); // will be looked up from namespace ns1
 // load multiple namespaces
 // the t function will be set to first namespace as default
 const { t, i18n } = useTranslation(['ns1', 'ns2', 'ns3']);
-t('key'); // will be looked up from namespace ns1
-t('key', { ns: 'ns2' }); // will be looked up from namespace ns2
+t($ => $.key); // will be looked up from namespace ns1
+t($ => $.key, { ns: 'ns2' }); // will be looked up from namespace ns2
 ```
+{% endtab %}
+{% endtabs %}
 
 ### Overriding the i18next instance
 
@@ -70,7 +106,9 @@ const { t, i18n } = useTranslation('ns1', { i18n });
 >
 > depends on i18next version >= 20.6.0
 
-```javascript
+{% tabs %}
+{% tab title="JavaScript" %}
+```jsx
 // having JSON in namespace "translation" like this:
 /*{
     "very": {
@@ -85,7 +123,29 @@ const { t, i18n } = useTranslation('ns1', { i18n });
 const { t } = useTranslation('translation', { keyPrefix: 'very.deeply.nested' });
 const text = t('key'); // "here"
 ```
+{% endtab %}
 
+{% tab title="TypeScript" %}
+```tsx
+// having JSON in namespace "translation" like this:
+/*{
+    "very": {
+      "deeply": {
+        "nested": {
+          "key": "here"
+        }
+      }
+    }
+}*/
+// you can define a keyPrefix to be used for the resulting t function
+const { t } = useTranslation('translation', { keyPrefix: 'very.deeply.nested' });
+const text = t($ => $.key); // "here"
+```
+{% endtab %}
+{% endtabs %}
+
+{% tabs %}
+{% tab title="JavaScript" %}
 {% hint style="warning" %}
 Do **not** use the `keyPrefix` option if you want to use keys with prefixed namespace notation:
 
@@ -96,16 +156,43 @@ const { t } = useTranslation('translation', { keyPrefix: 'very.deeply.nested' })
 const text = t('ns:key'); // this will not work
 ```
 {% endhint %}
+{% endtab %}
+
+{% tab title="TypeScript" %}
+{% hint style="warning" %}
+Do **not** use the `keyPrefix` option if you want to use keys with prefixed namespace notation:
+
+i.e.
+
+```javascript
+const { t } = useTranslation('translation', { keyPrefix: 'very.deeply.nested' });
+const text = t($ => $.ns.key); // this will not work
+```
+{% endhint %}
+{% endtab %}
+{% endtabs %}
 
 ### Optional lng option
 
 > available in react-i18next version >= 12.3.1
 
-```javascript
+{% tabs %}
+{% tab title="JavaScript" %}
+```jsx
 // you can pass a language to be used for the resulting t function
 const { t } = useTranslation('translation', { lng: 'de' });
 const text = t('key'); // "hier"
 ```
+{% endtab %}
+
+{% tab title="TypeScript" %}
+```tsx
+// you can pass a language to be used for the resulting t function
+const { t } = useTranslation('translation', { lng: 'de' });
+const text = t($ => $.key); // "hier"
+```
+{% endtab %}
+{% endtabs %}
 
 ### Not using Suspense
 

--- a/latest/using-with-hooks.md
+++ b/latest/using-with-hooks.md
@@ -72,6 +72,8 @@ root.render(
 );
 ```
 
+{% tabs %}
+{% tab title="JavaScript" %}
 {% hint style="info" %}
 If you need to access the `t` function or the `i18next` instance from outside of a React component you can simply import your `./i18n.js` and use the exported i18next instance:
 
@@ -81,6 +83,20 @@ import i18next from './i18n'
 i18next.t('my.key')
 ```
 {% endhint %}
+{% endtab %}
+
+{% tab title="TypeScript" %}
+{% hint style="info" %}
+If you need to access the `t` function or the `i18next` instance from outside of a React component you can simply import your `./i18n.js` and use the exported i18next instance:
+
+```
+import i18next from './i18n'
+
+i18next.t($ => $.my.key)
+```
+{% endhint %}
+{% endtab %}
+{% endtabs %}
 
 ### Translate your content
 
@@ -88,6 +104,8 @@ i18next.t('my.key')
 
 You can use the hook inside your functional components like:
 
+{% tabs %}
+{% tab title="JavaScript" %}
 ```jsx
 import React, { Suspense } from 'react';
 import { useTranslation } from 'react-i18next';
@@ -108,6 +126,31 @@ export default function App() {
   );
 }
 ```
+{% endtab %}
+
+{% tab title="TypeScript" %}
+```tsx
+import React, { Suspense } from 'react';
+import { useTranslation } from 'react-i18next';
+
+function MyComponent() {
+  const { t, i18n } = useTranslation();
+
+  return <h1>{t($ => $['Welcome to React'])}</h1>
+}
+
+// i18n translations might still be loaded by the http backend
+// use react's Suspense
+export default function App() {
+  return (
+    <Suspense fallback="loading">
+      <MyComponent />
+    </Suspense>
+  );
+}
+```
+{% endtab %}
+{% endtabs %}
 
 The useTranslation hook function takes one options argument. You can either pass in a namespace or an array of namespaces to load.
 
@@ -145,6 +188,8 @@ Please note the t function will be either bound to the default namespace defined
 
 There might be some legacy cases where you are still forced to use classes. Don't worry, we still provide a hoc to cover these cases:
 
+{% tabs %}
+{% tab title="JavaScript" %}
 ```jsx
 import React, { Component, Suspense } from 'react';
 import { withTranslation } from 'react-i18next';
@@ -170,6 +215,36 @@ export default function App() {
   );
 }
 ```
+{% endtab %}
+
+{% tab title="TypeScript" %}
+```tsx
+import React, { Component, Suspense } from 'react';
+import { withTranslation } from 'react-i18next';
+
+class LegacyComponentClass extends Component {
+  render() {
+    const { t } = this.props;
+
+    return (
+      <h1>{t($ => $['Welcome to React'])}</h1>
+    )
+  }
+}
+const MyComponent = withTranslation()(LegacyComponentClass)
+
+// i18n translations might still be loaded by the http backend
+// use react's Suspense
+export default function App() {
+  return (
+    <Suspense fallback="loading">
+      <MyComponent />
+    </Suspense>
+  );
+}
+```
+{% endtab %}
+{% endtabs %}
 
 The withTranslation hook function takes one options argument. You can either pass in a namespace or a array of namespaces to load.
 

--- a/latest/withtranslation-hoc.md
+++ b/latest/withtranslation-hoc.md
@@ -4,6 +4,8 @@
 
 The `withTranslation` is a classic HOC (higher order component) and gets the `t` function and `i18n` instance inside your component via props.
 
+{% tabs %}
+{% tab title="JavaScript" %}
 ```jsx
 import React from 'react';
 import { withTranslation } from 'react-i18next';
@@ -14,6 +16,21 @@ function MyComponent({ t, i18n }) {
 
 export default withTranslation()(MyComponent);
 ```
+{% endtab %}
+
+{% tab title="TypeScript" %}
+```tsx
+import React from 'react';
+import { withTranslation } from 'react-i18next';
+
+function MyComponent({ t, i18n }) {
+  return <p>{t($ => $['my translated text'])}</p>
+}
+
+export default withTranslation()(MyComponent);
+```
+{% endtab %}
+{% endtabs %}
 
 While you most time only need the t function to translate your content you also get the i18n instance to eg. change the language.
 
@@ -33,7 +50,9 @@ Use the `withTranslation` HOC to wrap **any component (class or function)** to a
 
 ### Loading namespaces
 
-```javascript
+{% tabs %}
+{% tab title="JavaScript" %}
+```jsx
 // load a specific namespace
 // the t function will be set to that namespace as default
 withTranslation('ns1')(MyComponent);
@@ -49,6 +68,27 @@ withTranslation(['ns1', 'ns2', 'ns3'])(MyComponent);
 this.props.t('key'); // will be looked up from namespace ns1
 this.props.t('key', { ns: 'ns2' }); // will be looked up from namespace ns2
 ```
+{% endtab %}
+
+{% tab title="TypeScript" %}
+```tsx
+// load a specific namespace
+// the t function will be set to that namespace as default
+withTranslation('ns1')(MyComponent);
+
+// inside your component MyComponent
+this.props.t('key'); // will be looked up from namespace ns1
+
+// load multiple namespaces
+// the t function will be set to first namespace as default
+withTranslation(['ns1', 'ns2', 'ns3'])(MyComponent);
+
+// inside your component MyComponent
+this.props.t($ => $.key); // will be looked up from namespace ns1
+this.props.t($ => $.key, { ns: 'ns2' }); // will be looked up from namespace ns2
+```
+{% endtab %}
+{% endtabs %}
 
 ### Overriding the i18next instance
 
@@ -132,13 +172,30 @@ export default Extended;
 
 To get proper type annotations while using TypeScript, import the interface `WithTranslation` and extend it with your own props interface.
 
+{% tabs %}
+{% tab title="JavaScript" %}
+```jsx
+import React, { Component } from 'react';
+import { withTranslation, WithTranslation } from 'react-i18next';
+
+class MyComponent extends Component {
+  render() {
+    return <div>{this.props.t('My translated text')}</div>
+  }
+}
+
+export default withTranslation()(MyComponent);
 ```
+{% endtab %}
+
+{% tab title="TypeScript" %}
+```tsx
 import React, { Component } from 'react';
 import { withTranslation, WithTranslation } from 'react-i18next';
 
 class MyComponent extends Component<IProps, IState> {
   render() {
-    return <div>{this.props.t('My translated text')}</div>
+    return <div>{this.props.t($ => $['My translated text'])}</div>
   }
 }
 
@@ -152,3 +209,5 @@ interface IState {
 
 export default withTranslation()(MyComponent);
 ```
+{% endtab %}
+{% endtabs %}

--- a/latest/withtranslation-hoc.md
+++ b/latest/withtranslation-hoc.md
@@ -77,7 +77,7 @@ this.props.t('key', { ns: 'ns2' }); // will be looked up from namespace ns2
 withTranslation('ns1')(MyComponent);
 
 // inside your component MyComponent
-this.props.t('key'); // will be looked up from namespace ns1
+this.props.t($ => $.key); // will be looked up from namespace ns1
 
 // load multiple namespaces
 // the t function will be set to first namespace as default

--- a/misc/testing.md
+++ b/misc/testing.md
@@ -17,7 +17,9 @@ import { MyComponent } from './myComponent';
 
 Or use [https://github.com/kadirahq/react-stubber](https://github.com/kadirahq/react-stubber) to stub i18n functionality:
 
-```javascript
+{% tabs %}
+{% tab title="JavaScript" %}
+```jsx
 const tDefault = (key) => key;
 const StubbableInterpolate = mayBeStubbed(Interpolate);
 const stubInterpolate = function () {
@@ -27,6 +29,21 @@ const stubInterpolate = function () {
   });
 };
 ```
+{% endtab %}
+
+{% tab title="TypeScript" %}
+```tsx
+const tDefault = (key) => key;
+const StubbableInterpolate = mayBeStubbed(Interpolate);
+const stubInterpolate = function () {
+  stub(StubbableInterpolate, (props, context) => {
+    const t = (context && context.t) || tDefault;
+    return (<span>{t($ => $[props.i18nKey])}</span>);
+  });
+};
+```
+{% endtab %}
+{% endtabs %}
 
 Or mock it like:
 
@@ -66,6 +83,8 @@ jest.mock('react-i18next', () => ({
 
 or, you can also spy the `t` function:
 
+{% tabs %}
+{% tab title="JavaScript" %}
 <pre class="language-jsx"><code class="lang-jsx"><strong>// implementation
 </strong>import React from 'react';
 import { useTranslation } from 'react-i18next';
@@ -107,6 +126,52 @@ it('test render', () => {
   expect(tSpy).toHaveBeenLastCalledWith('some.key', { some: 'variable' });
 });
 </code></pre>
+{% endtab %}
+
+{% tab title="TypeScript" %}
+<pre class="language-tsx"><code class="lang-tsx"><strong>// implementation
+</strong>import React from 'react';
+import { useTranslation } from 'react-i18next';
+
+export default function CustomComponent() {
+  const { t } = useTranslation();
+
+  return &#x3C;div>{t($ => $.some.key, { some: 'variable' })}&#x3C;/div>;
+}
+
+<strong>// test
+</strong>import React from 'react';
+import { mount } from 'enzyme';
+import UseTranslationWithInterpolation from './UseTranslationWithInterpolation';
+import { useTranslation } from 'react-i18next';
+
+jest.mock('react-i18next', () => ({
+  useTranslation: jest.fn(),
+}));
+
+it('test render', () => {
+  const useTranslationSpy = useTranslation;
+  const tSpy = jest.fn((str) => str);
+  useTranslationSpy.mockReturnValue({
+    t: tSpy,
+    i18n: {
+      changeLanguage: () => new Promise(() => {}),
+    },
+  });
+
+  const mounted = mount(&#x3C;UseTranslationWithInterpolation />);
+
+  // console.log(mounted.debug());
+  expect(mounted.contains(&#x3C;div>some.key&#x3C;/div>)).toBe(true);
+
+  // If you want you can also check how the t function has been called,
+  // but basically this is testing your mock and not the actual code.
+  expect(tSpy).toHaveBeenCalledTimes(1);
+  expect(tSpy).toHaveBeenLastCalledWith('some.key', { some: 'variable' });
+});
+</code></pre>
+{% endtab %}
+{% endtabs %}
 
 {% hint style="success" %}
 You can find a full sample for testing with jest here: [https://github.com/i18next/react-i18next/tree/master/example/test-jest](https://github.com/i18next/react-i18next/tree/master/example/test-jest)

--- a/misc/using-with-icu-format.md
+++ b/misc/using-with-icu-format.md
@@ -48,7 +48,9 @@ export default i18n;
 
 ### using t function
 
-```javascript
+{% tabs %}
+{% tab title="JavaScript" %}
+```jsx
 import React, { Component } from 'react';
 import { useTranslation } from 'react-i18next';
 
@@ -67,6 +69,30 @@ function MyComponent() {
 // result:
 <div>500 persons</div>
 ```
+{% endtab %}
+
+{% tab title="TypeScript" %}
+```tsx
+import React, { Component } from 'react';
+import { useTranslation } from 'react-i18next';
+
+function MyComponent() {
+  const { t, i18n } = useTranslation();
+  // or const [t, i18n] = useTranslation();
+  
+  return <div>{t($ => $.icu, { numPersons: 500 })}</div>
+}
+
+// ...
+
+// json
+"icu": "{numPersons, plural, =0 {no persons} =1 {one person} other {# persons}}",
+
+// result:
+<div>500 persons</div>
+```
+{% endtab %}
+{% endtabs %}
 
 ### using the Trans Component
 
@@ -382,7 +408,7 @@ import { SelectOrdinal } from 'react-i18next/icu.macro';
 ```
 
 {% hint style="info" %}
-The needed plural forms can be looked up in the official unicode cldr table: [http://www.unicode.org/cldr/charts/33/supplemental/language_plural_rules.html](http://www.unicode.org/cldr/charts/33/supplemental/language_plural_rules.html)
+The needed plural forms can be looked up in the official unicode cldr table: [http://www.unicode.org/cldr/charts/33/supplemental/language\_plural\_rules.html](http://www.unicode.org/cldr/charts/33/supplemental/language_plural_rules.html)
 
 In addition to the plural forms you can specify results for given number values like show above:
 

--- a/misc/using-with-icu-format.md
+++ b/misc/using-with-icu-format.md
@@ -408,7 +408,7 @@ import { SelectOrdinal } from 'react-i18next/icu.macro';
 ```
 
 {% hint style="info" %}
-The needed plural forms can be looked up in the official unicode cldr table: [http://www.unicode.org/cldr/charts/33/supplemental/language\_plural\_rules.html](http://www.unicode.org/cldr/charts/33/supplemental/language_plural_rules.html)
+The needed plural forms can be looked up in the official unicode cldr table: [http://www.unicode.org/cldr/charts/33/supplemental/language_plural_rules.html](http://www.unicode.org/cldr/charts/33/supplemental/language_plural_rules.html)
 
 In addition to the plural forms you can specify results for given number values like show above:
 


### PR DESCRIPTION
This PR adds documentation to support the addition of the new [selector API](https://github.com/i18next/i18next/pull/2322) for TypeScript users.

The approach I took was simply to add tabs anywhere API usage differed between JavaScript and TypeScript:

![react-i18next-gitbook-tabs](https://github.com/user-attachments/assets/5bab2f05-a280-4bf5-8709-9d8db632fce0)

Here's the companion PR for [i18next-gitbook](https://github.com/i18next/i18next-gitbook/pull/235)

#### Checklist

- [x] only relevant code is changed (make a diff before you submit the PR)
- [-] run tests `npm run test`
- [-] tests are included
- [x] commit message and code follows the [Developer's Certification of Origin](https://github.com/i18next/.github/blob/master/CONTRIBUTING.md)

#### Checklist (for documentation change)

- [x] only relevant documentation part is changed (make a diff before you submit the PR)
- [x] motivation/reason is provided
- [x] commit message and code follows the [Developer's Certification of Origin](https://github.com/i18next/.github/blob/master/CONTRIBUTING.md)